### PR TITLE
Test cleanup + refactoring in `BondingCurve` and `UnitAuction`

### DIFF
--- a/contracts/BondingCurve.sol
+++ b/contracts/BondingCurve.sol
@@ -56,11 +56,10 @@ contract BondingCurve is IBondingCurve, Proxiable, ReentrancyGuard, Ownable {
     uint256 public immutable STANDARD_PRECISION;
     address public immutable COLLATERAL_BURN_ADDRESS;
 
-    IERC20 public immutable collateralToken;
-    uint256 private immutable collateralTokenDecimals;
-
     IUnitToken public immutable unitToken;
     IMineToken public immutable mineToken;
+    IERC20 public immutable collateralToken;
+    uint256 private immutable collateralTokenDecimals;
 
     IInflationOracle public immutable inflationOracle;
     ICollateralUsdOracle public immutable collateralUsdOracle;
@@ -98,20 +97,20 @@ contract BondingCurve is IBondingCurve, Proxiable, ReentrancyGuard, Ownable {
      * uninitializable, which makes it unusable when called directly.
      */
     constructor(
-        IERC20 _collateralToken,
-        address collateralBurnAddress,
         IUnitToken _unitToken,
         IMineToken _mineToken,
+        IERC20 _collateralToken,
+        address collateralBurnAddress,
         IInflationOracle _inflationOracle,
         ICollateralUsdOracle _collateralUsdOracle
     ) {
         STANDARD_PRECISION = ProtocolConstants.STANDARD_PRECISION;
         COLLATERAL_BURN_ADDRESS = collateralBurnAddress;
 
-        collateralToken = _collateralToken;
-        collateralTokenDecimals = _collateralToken.decimals();
         unitToken = _unitToken;
         mineToken = _mineToken;
+        collateralToken = _collateralToken;
+        collateralTokenDecimals = _collateralToken.decimals();
         inflationOracle = _inflationOracle;
         collateralUsdOracle = _collateralUsdOracle;
 

--- a/contracts/BondingCurve.sol
+++ b/contracts/BondingCurve.sol
@@ -59,7 +59,7 @@ contract BondingCurve is IBondingCurve, Proxiable, ReentrancyGuard, Ownable {
     IUnitToken public immutable unitToken;
     IMineToken public immutable mineToken;
     IERC20 public immutable collateralToken;
-    uint256 private immutable collateralTokenDecimals;
+    uint256 internal immutable collateralTokenDecimals;
 
     IInflationOracle public immutable inflationOracle;
     ICollateralUsdOracle public immutable collateralUsdOracle;

--- a/contracts/auctions/UnitAuction.sol
+++ b/contracts/auctions/UnitAuction.sol
@@ -43,9 +43,9 @@ contract UnitAuction is IUnitAuction, Proxiable, Ownable {
     uint256 public immutable STANDARD_PRECISION;
 
     IBondingCurve public immutable bondingCurve;
+    IUnitToken public immutable unitToken;
     IERC20 public immutable collateralToken;
     uint256 private immutable collateralTokenDecimals;
-    IUnitToken public immutable unitToken;
 
     uint8 public constant AUCTION_VARIANT_NONE = 1;
     uint8 public constant AUCTION_VARIANT_CONTRACTION = 2;
@@ -96,10 +96,10 @@ contract UnitAuction is IUnitAuction, Proxiable, Ownable {
         STANDARD_PRECISION = ProtocolConstants.STANDARD_PRECISION;
 
         bondingCurve = _bondingCurve;
+        unitToken = _unitToken;
         IERC20 _collateralToken = _bondingCurve.collateralToken();
         collateralToken = _collateralToken;
         collateralTokenDecimals = _collateralToken.decimals();
-        unitToken = _unitToken;
 
         super.initialize();
     }

--- a/contracts/auctions/UnitAuction.sol
+++ b/contracts/auctions/UnitAuction.sol
@@ -45,7 +45,7 @@ contract UnitAuction is IUnitAuction, Proxiable, Ownable {
     IBondingCurve public immutable bondingCurve;
     IUnitToken public immutable unitToken;
     IERC20 public immutable collateralToken;
-    uint256 private immutable collateralTokenDecimals;
+    uint256 internal immutable collateralTokenDecimals;
 
     uint8 public constant AUCTION_VARIANT_NONE = 1;
     uint8 public constant AUCTION_VARIANT_CONTRACTION = 2;

--- a/contracts/test/BondingCurveHarness.sol
+++ b/contracts/test/BondingCurveHarness.sol
@@ -7,18 +7,18 @@ import { unwrap } from '@prb/math/src/UD60x18.sol';
 
 contract BondingCurveHarness is BondingCurve {
     constructor(
-        IERC20 _collateralToken,
-        address collateralBurnAddress,
         IUnitToken _unitToken,
         IMineToken _mineToken,
+        IERC20 _collateralToken,
+        address collateralBurnAddress,
         IInflationOracle _inflationOracle,
         ICollateralUsdOracle _collateralUsdOracle
     )
         BondingCurve(
-            _collateralToken,
-            collateralBurnAddress,
             _unitToken,
             _mineToken,
+            _collateralToken,
+            collateralBurnAddress,
             _inflationOracle,
             _collateralUsdOracle
         )

--- a/contracts/test/BondingCurveHarness.sol
+++ b/contracts/test/BondingCurveHarness.sol
@@ -24,7 +24,11 @@ contract BondingCurveHarness is BondingCurve {
         )
     {}
 
-    function exposed_getUnitUsdPriceForTimestamp(uint256 timestamp) public view returns (uint256) {
+    function exposed_getUnitUsdPriceForTimestamp(uint256 timestamp) external view returns (uint256) {
         return unwrap(_getUnitUsdPriceForTimestamp(timestamp));
+    }
+
+    function exposed_collateralTokenDecimals() external view returns (uint256) {
+        return collateralTokenDecimals;
     }
 }

--- a/contracts/test/UnitAuctionHarness.sol
+++ b/contracts/test/UnitAuctionHarness.sol
@@ -9,23 +9,27 @@ import '../UnitToken.sol';
 contract UnitAuctionHarness is UnitAuction {
     constructor(BondingCurve _bondingCurve, UnitToken _unitToken) UnitAuction(_bondingCurve, _unitToken) {}
 
-    function exposed_startContractionAuction() public returns (AuctionState memory _auctionState) {
+    function exposed_startContractionAuction() external returns (AuctionState memory _auctionState) {
         return _startContractionAuction();
     }
 
-    function exposed_startExpansionAuction() public returns (AuctionState memory _auctionState) {
+    function exposed_startExpansionAuction() external returns (AuctionState memory _auctionState) {
         return _startExpansionAuction();
     }
 
-    function exposed_terminateAuction() public returns (AuctionState memory _auctionState) {
+    function exposed_terminateAuction() external returns (AuctionState memory _auctionState) {
         return _terminateAuction();
     }
 
-    function exposed_inContractionRange(uint256 reserveRatio) public pure returns (bool) {
+    function exposed_inContractionRange(uint256 reserveRatio) external pure returns (bool) {
         return inContractionRange(reserveRatio);
     }
 
-    function exposed_inExpansionRange(uint256 reserveRatio) public pure returns (bool) {
+    function exposed_inExpansionRange(uint256 reserveRatio) external pure returns (bool) {
         return inExpansionRange(reserveRatio);
+    }
+
+    function exposed_collateralTokenDecimals() external view returns (uint256) {
+        return collateralTokenDecimals;
     }
 }

--- a/foundry/test/bondingCurve/BondingCurve.t.sol
+++ b/foundry/test/bondingCurve/BondingCurve.t.sol
@@ -23,6 +23,7 @@ contract BondingCurveHarnessTest is BondingCurveTestBase {
         assertEq(address(bondingCurveProxy.unitToken()), address(unitToken));
         assertEq(address(bondingCurveProxy.mineToken()), address(mineToken));
         assertEq(address(bondingCurveProxy.collateralToken()), address(collateralToken));
+        assertEq(bondingCurveProxy.exposed_collateralTokenDecimals(), collateralToken.decimals());
         assertEq(address(bondingCurveProxy.inflationOracle()), address(inflationOracle));
         assertEq(address(bondingCurveProxy.collateralUsdOracle()), address(collateralUsdOracle));
     }

--- a/foundry/test/bondingCurve/BondingCurve.t.sol
+++ b/foundry/test/bondingCurve/BondingCurve.t.sol
@@ -8,16 +8,23 @@ import { TestUtils } from '../utils/TestUtils.t.sol';
 
 contract BondingCurveHarnessTest is BondingCurveTestBase {
     /**
-     * ================ COLLATERAL_BURN_ADDRESS() ================
+     * ================ initial state ================
      */
 
-    function test_COLLATERAL_BURN_ADDRESS_CorrectlySetsAddressInProxyContract() public {
-        // Arrange & Act
-        (, bytes memory data) = address(bondingCurveProxyType).call(abi.encodeWithSelector(0xb8588101));
+    function test_implementation_isInitalized() public {
+        assertEq(bondingCurveImplementation.initialized(), true);
+    }
 
-        // Assert
-        address collateralBurnAddress = abi.decode(data, (address));
-        assertEq(collateralBurnAddress, TestUtils.COLLATERAL_BURN_ADDRESS);
+    function test_proxy_stateVariablesAndImmutablesSetCorrectly() public {
+        assertEq(bondingCurveProxy.initialized(), true);
+        assertEq(bondingCurveProxy.STANDARD_PRECISION(), TestUtils.STANDARD_PRECISION);
+        assertEq(bondingCurveProxy.COLLATERAL_BURN_ADDRESS(), TestUtils.COLLATERAL_BURN_ADDRESS);
+
+        assertEq(address(bondingCurveProxy.unitToken()), address(unitToken));
+        assertEq(address(bondingCurveProxy.mineToken()), address(mineToken));
+        assertEq(address(bondingCurveProxy.collateralToken()), address(collateralToken));
+        assertEq(address(bondingCurveProxy.inflationOracle()), address(inflationOracle));
+        assertEq(address(bondingCurveProxy.collateralUsdOracle()), address(collateralUsdOracle));
     }
 
     /**

--- a/foundry/test/bondingCurve/BondingCurveTestBase.t.sol
+++ b/foundry/test/bondingCurve/BondingCurveTestBase.t.sol
@@ -16,15 +16,14 @@ import { TestUtils } from '../utils/TestUtils.t.sol';
 abstract contract BondingCurveTestBase is Test {
     uint256 internal constant ORACLE_UPDATE_INTERVAL = 30 days;
 
-    CollateralERC20TokenTest public collateralToken;
-    InflationOracleHarness public inflationOracle;
-    CollateralUsdOracleMock public collateralUsdOracle;
-    UnitToken public unitToken;
-    MineToken public mineToken;
-
-    Proxy public bondingCurveProxyType;
     BondingCurveHarness public bondingCurveImplementation;
     BondingCurveHarness public bondingCurveProxy;
+
+    CollateralERC20TokenTest public collateralToken;
+    UnitToken public unitToken;
+    MineToken public mineToken;
+    InflationOracleHarness public inflationOracle;
+    CollateralUsdOracleMock public collateralUsdOracle;
 
     address public wallet = vm.addr(1);
 
@@ -53,21 +52,19 @@ abstract contract BondingCurveTestBase is Test {
 
         // set up BondingCurve contract
         bondingCurveImplementation = new BondingCurveHarness(
-            collateralToken,
-            TestUtils.COLLATERAL_BURN_ADDRESS,
             unitToken,
             mineToken,
+            collateralToken,
+            TestUtils.COLLATERAL_BURN_ADDRESS,
             inflationOracle,
             collateralUsdOracle
         );
-        bondingCurveProxyType = new Proxy(address(this));
-
-        bondingCurveProxyType.upgradeToAndCall(
+        Proxy proxy = new Proxy(address(this));
+        proxy.upgradeToAndCall(
             address(bondingCurveImplementation),
             abi.encodeWithSelector(Proxiable.initialize.selector)
         );
-
-        bondingCurveProxy = BondingCurveHarness(payable(bondingCurveProxyType));
+        bondingCurveProxy = BondingCurveHarness(payable(proxy));
 
         unitToken.setMinter(address(bondingCurveProxy), true);
         unitToken.setBurner(address(bondingCurveProxy), true);

--- a/foundry/test/unitAuction/UnitAuction.t.sol
+++ b/foundry/test/unitAuction/UnitAuction.t.sol
@@ -9,11 +9,17 @@ import { TestUtils } from '../utils/TestUtils.t.sol';
 import { Ownable } from '../../../contracts/abstracts/Ownable.sol';
 
 contract UnitAuctionTest is UnitAuctionTestBase {
-    function test_constructor_stateVariablesSetCorrectly() public {
-        // Arrange & Act & Assert
+    function test_implementation_isInitialized() public {
         assertEq(unitAuctionImplementation.initialized(), true);
+    }
+
+    function test_proxy_stateVariablesAndImmutablesSetCorrectly() public {
+        assertEq(unitAuctionProxy.initialized(), true);
+        assertEq(unitAuctionProxy.STANDARD_PRECISION(), TestUtils.STANDARD_PRECISION);
+
         assertEq(address(unitAuctionProxy.bondingCurve()), address(bondingCurveProxy));
         assertEq(address(unitAuctionProxy.unitToken()), address(unitToken));
+        assertEq(address(unitAuctionProxy.collateralToken()), address(collateralToken));
     }
 
     function test_receive_NoDirectTransfer() public {

--- a/foundry/test/unitAuction/UnitAuction.t.sol
+++ b/foundry/test/unitAuction/UnitAuction.t.sol
@@ -20,6 +20,7 @@ contract UnitAuctionTest is UnitAuctionTestBase {
         assertEq(address(unitAuctionProxy.bondingCurve()), address(bondingCurveProxy));
         assertEq(address(unitAuctionProxy.unitToken()), address(unitToken));
         assertEq(address(unitAuctionProxy.collateralToken()), address(collateralToken));
+        assertEq(unitAuctionProxy.exposed_collateralTokenDecimals(), collateralToken.decimals());
     }
 
     function test_receive_NoDirectTransfer() public {


### PR DESCRIPTION
- Clean up the use of proxy in tests
- Add a test for `BondingCurve.initialized()` in the implementation contract
- Minor refactor to always prioritize the protocol tokens in the parameter list
